### PR TITLE
Add support for Step Function type of either STANDARD (default) or EX…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 .terraform
-*.tfstate.backup
-*.tfstate
-*.tfvars
-*.tfplan
+terraform.tfstate
+*.tfstate*
+terraform.tfvars
 
-builds/
-
-__pycache__/
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ EOF
   tags = {
     Module = "my"
   }
+  
+  type = "STANDARD"
 }
 ```
 
@@ -127,13 +129,13 @@ module "step_function" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 2.67 |
+| aws | >= 3.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.67 |
+| aws | >= 3.27 |
 
 ## Inputs
 
@@ -167,6 +169,7 @@ module "step_function" {
 | service\_integrations | Map of AWS service integrations to allow in IAM role policy | `any` | `{}` | no |
 | tags | Maps of tags to assign to the Step Function | `map(string)` | `{}` | no |
 | trusted\_entities | Step Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
+  type | Determines whether a Standard or Express state machine is created. | `string` | `STANDARD` | no |
 | use\_existing\_role | Whether to use an existing IAM role for this Step Function | `bool` | `false` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ EOF
     }
   }
 
+  type = "STANDARD"
+
   tags = {
     Module = "my"
   }
-  
-  type = "STANDARD"
 }
 ```
 
@@ -169,7 +169,7 @@ module "step_function" {
 | service\_integrations | Map of AWS service integrations to allow in IAM role policy | `any` | `{}` | no |
 | tags | Maps of tags to assign to the Step Function | `map(string)` | `{}` | no |
 | trusted\_entities | Step Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
-  type | Determines whether a Standard or Express state machine is created. | `string` | `STANDARD` | no |
+| type | Determines whether a Standard or Express state machine is created. The default is STANDARD. Valid Values: STANDARD \| EXPRESS | `string` | `"STANDARD"` | no |
 | use\_existing\_role | Whether to use an existing IAM role for this Step Function | `bool` | `false` | no |
 
 ## Outputs

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -23,14 +23,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 2.67 |
+| aws | >= 3.27 |
 | random | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.67 |
+| aws | >= 3.27 |
 | random | >= 2 |
 
 ## Inputs

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -131,6 +131,8 @@ EOF
   tags = {
     Module = "step_function"
   }
+
+  type = "STANDARD"
 }
 
 ###########

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -36,6 +36,8 @@ module "step_function" {
 
   name = random_pet.this.id
 
+  type = "express"
+
   definition = local.definition_template
 
   service_integrations = {
@@ -131,8 +133,6 @@ EOF
   tags = {
     Module = "step_function"
   }
-
-  type = "STANDARD"
 }
 
 ###########

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.27"
     random = ">= 2"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  create_role = var.create && var.create_role && ! var.use_existing_role
+  create_role = var.create && var.create_role && !var.use_existing_role
   aws_region  = local.create_role && var.aws_region_assume_role == "" ? data.aws_region.current[0].name : var.aws_region_assume_role
 
   role_name = local.create_role ? coalesce(var.role_name, var.name) : null
@@ -13,9 +13,9 @@ resource "aws_sfn_state_machine" "this" {
   role_arn   = var.use_existing_role ? var.role_arn : aws_iam_role.this[0].arn
   definition = var.definition
 
-  tags = merge({ Name = var.name }, var.tags)
+  type = upper(var.type)
 
-  type = var.type
+  tags = merge({ Name = var.name }, var.tags)
 }
 
 ###########

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,8 @@ resource "aws_sfn_state_machine" "this" {
   definition = var.definition
 
   tags = merge({ Name = var.name }, var.tags)
+
+  type = var.type
 }
 
 ###########

--- a/variables.tf
+++ b/variables.tf
@@ -46,12 +46,13 @@ variable "tags" {
 
 variable "type" {
   description = "Determines whether a Standard or Express state machine is created. The default is STANDARD. Valid Values: STANDARD | EXPRESS"
-  default = "STANDARD"
+  type        = string
+  default     = "STANDARD"
+
   validation {
-    condition = contains(["STANDARD", "EXPRESS"], var.type)
+    condition     = contains(["STANDARD", "EXPRESS"], upper(var.type))
     error_message = "Step Function type must be one of the following (STANDARD | EXPRESS)."
   }
-  type = string
 }
 
 ###########

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,16 @@ variable "tags" {
   default     = {}
 }
 
+variable "type" {
+  description = "Determines whether a Standard or Express state machine is created. The default is STANDARD. Valid Values: STANDARD | EXPRESS"
+  default = "STANDARD"
+  validation {
+    condition = contains(["STANDARD", "EXPRESS"], var.type)
+    error_message = "Step Function type must be one of the following (STANDARD | EXPRESS)."
+  }
+  type = string
+}
+
 ###########
 # IAM Role
 ###########

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.67"
+    aws = ">= 3.27"
   }
 }


### PR DESCRIPTION
…PRESS

## Description
Adding support to create either a Standard or Express step function.

## Motivation and Context
Support was added in the AWS Terraform provider with version 3.27 to allow for express step functions to be created. This enables that change through this module.

## Breaking Changes
None  

## How Has This Been Tested?
Created the example resources in a personal AWS account without issue.
