### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
 
+# Terraform lockfile
 .terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ module "step_function" {
 |------|---------|
 | aws | >= 3.27 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_policy) |
+| [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_policy_attachment) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_role_policy_attachment) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/data-sources/region) |
+| [aws_sfn_state_machine](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/sfn_state_machine) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -182,7 +198,6 @@ module "step_function" {
 | this\_state\_machine\_creation\_date | The date the Step Function was created |
 | this\_state\_machine\_id | The ARN of the Step Function |
 | this\_state\_machine\_status | The current status of the Step Function |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ module "step_function" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.13.1 |
 | aws | >= 3.27 |
 
 ## Providers
@@ -145,11 +145,11 @@ No Modules.
 
 | Name |
 |------|
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_policy) |
 | [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_policy_attachment) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_role) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_policy) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_role_policy_attachment) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/iam_role) |
 | [aws_region](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/data-sources/region) |
 | [aws_sfn_state_machine](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/sfn_state_machine) |
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -33,6 +33,20 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws | >= 3.27 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| disabled_step_function | ../../ |  |
+| step_function | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/3.27/docs/resources/sqs_queue) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -47,5 +61,4 @@ No input.
 | this\_state\_machine\_creation\_date | The date the State Machine was created |
 | this\_state\_machine\_id | The ARN of the State Machine |
 | this\_state\_machine\_status | The current status of the State Machine |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.13.1 |
 | aws | >= 3.27 |
 | random | >= 2 |
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 3.27"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  create_role = var.create && var.create_role && !var.use_existing_role
+  create_role = var.create && var.create_role && ! var.use_existing_role
   aws_region  = local.create_role && var.aws_region_assume_role == "" ? data.aws_region.current[0].name : var.aws_region_assume_role
 
   role_name = local.create_role ? coalesce(var.role_name, var.name) : null

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 3.27"


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
Yes but no - required terraform version raised to 0.13.1 (0.13.0 had a number of issues since it was the first release of a major change) due to using variable validation (added prior to this PR)

## How Has This Been Tested?
N/A
