### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -128,76 +128,85 @@ module "step_function" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.1 |
-| aws | >= 3.27 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
-| [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
-| [aws_sfn_state_machine](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sfn_state_machine) |
+| Name | Type |
+|------|------|
+| [aws_iam_policy.additional_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.additional_json](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.additional_jsons](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy_attachment.additional_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.additional_json](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.additional_jsons](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.additional_many](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.additional_one](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_sfn_state_machine.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sfn_state_machine) | resource |
+| [aws_iam_policy_document.additional_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| attach\_policies | Controls whether list of policies should be added to IAM role | `bool` | `false` | no |
-| attach\_policies\_for\_integrations | Whether to attach AWS Service policies to IAM role | `bool` | `true` | no |
-| attach\_policy | Controls whether policy should be added to IAM role | `bool` | `false` | no |
-| attach\_policy\_json | Controls whether policy\_json should be added to IAM role | `bool` | `false` | no |
-| attach\_policy\_jsons | Controls whether policy\_jsons should be added to IAM role | `bool` | `false` | no |
-| attach\_policy\_statements | Controls whether policy\_statements should be added to IAM role | `bool` | `false` | no |
-| aws\_region\_assume\_role | Name of AWS regions where IAM role can be assumed by the Step Function | `string` | `""` | no |
-| create | Whether to create Step Function resource | `bool` | `true` | no |
-| create\_role | Whether to create IAM role for the Step Function | `bool` | `true` | no |
-| definition | The Amazon States Language definition of the Step Function | `string` | `""` | no |
-| name | The name of the Step Function | `string` | `""` | no |
-| number\_of\_policies | Number of policies to attach to IAM role | `number` | `0` | no |
-| number\_of\_policy\_jsons | Number of policies JSON to attach to IAM role | `number` | `0` | no |
-| policies | List of policy statements ARN to attach to IAM role | `list(string)` | `[]` | no |
-| policy | An additional policy document ARN to attach to IAM role | `string` | `null` | no |
-| policy\_json | An additional policy document as JSON to attach to IAM role | `string` | `null` | no |
-| policy\_jsons | List of additional policy documents as JSON to attach to IAM role | `list(string)` | `[]` | no |
-| policy\_statements | Map of dynamic policy statements to attach to IAM role | `any` | `{}` | no |
-| role\_arn | The Amazon Resource Name (ARN) of the IAM role to use for this Step Function | `string` | `""` | no |
-| role\_description | Description of IAM role to use for Step Function | `string` | `null` | no |
-| role\_force\_detach\_policies | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |
-| role\_name | Name of IAM role to use for Step Function | `string` | `null` | no |
-| role\_path | Path of IAM role to use for Step Function | `string` | `null` | no |
-| role\_permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the IAM role used by Step Function | `string` | `null` | no |
-| role\_tags | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
-| service\_integrations | Map of AWS service integrations to allow in IAM role policy | `any` | `{}` | no |
-| tags | Maps of tags to assign to the Step Function | `map(string)` | `{}` | no |
-| trusted\_entities | Step Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
-| type | Determines whether a Standard or Express state machine is created. The default is STANDARD. Valid Values: STANDARD \| EXPRESS | `string` | `"STANDARD"` | no |
-| use\_existing\_role | Whether to use an existing IAM role for this Step Function | `bool` | `false` | no |
+| <a name="input_attach_policies"></a> [attach\_policies](#input\_attach\_policies) | Controls whether list of policies should be added to IAM role | `bool` | `false` | no |
+| <a name="input_attach_policies_for_integrations"></a> [attach\_policies\_for\_integrations](#input\_attach\_policies\_for\_integrations) | Whether to attach AWS Service policies to IAM role | `bool` | `true` | no |
+| <a name="input_attach_policy"></a> [attach\_policy](#input\_attach\_policy) | Controls whether policy should be added to IAM role | `bool` | `false` | no |
+| <a name="input_attach_policy_json"></a> [attach\_policy\_json](#input\_attach\_policy\_json) | Controls whether policy\_json should be added to IAM role | `bool` | `false` | no |
+| <a name="input_attach_policy_jsons"></a> [attach\_policy\_jsons](#input\_attach\_policy\_jsons) | Controls whether policy\_jsons should be added to IAM role | `bool` | `false` | no |
+| <a name="input_attach_policy_statements"></a> [attach\_policy\_statements](#input\_attach\_policy\_statements) | Controls whether policy\_statements should be added to IAM role | `bool` | `false` | no |
+| <a name="input_aws_region_assume_role"></a> [aws\_region\_assume\_role](#input\_aws\_region\_assume\_role) | Name of AWS regions where IAM role can be assumed by the Step Function | `string` | `""` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create Step Function resource | `bool` | `true` | no |
+| <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Whether to create IAM role for the Step Function | `bool` | `true` | no |
+| <a name="input_definition"></a> [definition](#input\_definition) | The Amazon States Language definition of the Step Function | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the Step Function | `string` | `""` | no |
+| <a name="input_number_of_policies"></a> [number\_of\_policies](#input\_number\_of\_policies) | Number of policies to attach to IAM role | `number` | `0` | no |
+| <a name="input_number_of_policy_jsons"></a> [number\_of\_policy\_jsons](#input\_number\_of\_policy\_jsons) | Number of policies JSON to attach to IAM role | `number` | `0` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | List of policy statements ARN to attach to IAM role | `list(string)` | `[]` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | An additional policy document ARN to attach to IAM role | `string` | `null` | no |
+| <a name="input_policy_json"></a> [policy\_json](#input\_policy\_json) | An additional policy document as JSON to attach to IAM role | `string` | `null` | no |
+| <a name="input_policy_jsons"></a> [policy\_jsons](#input\_policy\_jsons) | List of additional policy documents as JSON to attach to IAM role | `list(string)` | `[]` | no |
+| <a name="input_policy_statements"></a> [policy\_statements](#input\_policy\_statements) | Map of dynamic policy statements to attach to IAM role | `any` | `{}` | no |
+| <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | The Amazon Resource Name (ARN) of the IAM role to use for this Step Function | `string` | `""` | no |
+| <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Description of IAM role to use for Step Function | `string` | `null` | no |
+| <a name="input_role_force_detach_policies"></a> [role\_force\_detach\_policies](#input\_role\_force\_detach\_policies) | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role to use for Step Function | `string` | `null` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role to use for Step Function | `string` | `null` | no |
+| <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM role used by Step Function | `string` | `null` | no |
+| <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
+| <a name="input_service_integrations"></a> [service\_integrations](#input\_service\_integrations) | Map of AWS service integrations to allow in IAM role policy | `any` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Maps of tags to assign to the Step Function | `map(string)` | `{}` | no |
+| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | Step Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
+| <a name="input_type"></a> [type](#input\_type) | Determines whether a Standard or Express state machine is created. The default is STANDARD. Valid Values: STANDARD \| EXPRESS | `string` | `"STANDARD"` | no |
+| <a name="input_use_existing_role"></a> [use\_existing\_role](#input\_use\_existing\_role) | Whether to use an existing IAM role for this Step Function | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_role\_arn | The ARN of the IAM role created for the Step Function |
-| this\_role\_name | The name of the IAM role created for the Step Function |
-| this\_state\_machine\_arn | The ARN of the Step Function |
-| this\_state\_machine\_creation\_date | The date the Step Function was created |
-| this\_state\_machine\_id | The ARN of the Step Function |
-| this\_state\_machine\_status | The current status of the Step Function |
+| <a name="output_this_role_arn"></a> [this\_role\_arn](#output\_this\_role\_arn) | The ARN of the IAM role created for the Step Function |
+| <a name="output_this_role_name"></a> [this\_role\_name](#output\_this\_role\_name) | The name of the IAM role created for the Step Function |
+| <a name="output_this_state_machine_arn"></a> [this\_state\_machine\_arn](#output\_this\_state\_machine\_arn) | The ARN of the Step Function |
+| <a name="output_this_state_machine_creation_date"></a> [this\_state\_machine\_creation\_date](#output\_this\_state\_machine\_creation\_date) | The date the Step Function was created |
+| <a name="output_this_state_machine_id"></a> [this\_state\_machine\_id](#output\_this\_state\_machine\_id) | The ARN of the Step Function |
+| <a name="output_this_state_machine_status"></a> [this\_state\_machine\_status](#output\_this\_state\_machine\_status) | The current status of the Step Function |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,43 +22,43 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.1 |
-| aws | >= 3.27 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.27 |
-| random | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| disabled_step_function | ../../ |  |
-| step_function | ../../ |  |
+| <a name="module_disabled_step_function"></a> [disabled\_step\_function](#module\_disabled\_step\_function) | ../../ |  |
+| <a name="module_step_function"></a> [step\_function](#module\_step\_function) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_sqs_queue.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_role\_arn | The ARN of the IAM role created for the State Machine |
-| this\_role\_name | The name of the IAM role created for the State Machine |
-| this\_state\_machine\_arn | The ARN of the State Machine |
-| this\_state\_machine\_creation\_date | The date the State Machine was created |
-| this\_state\_machine\_id | The ARN of the State Machine |
-| this\_state\_machine\_status | The current status of the State Machine |
+| <a name="output_this_role_arn"></a> [this\_role\_arn](#output\_this\_role\_arn) | The ARN of the IAM role created for the State Machine |
+| <a name="output_this_role_name"></a> [this\_role\_name](#output\_this\_role\_name) | The name of the IAM role created for the State Machine |
+| <a name="output_this_state_machine_arn"></a> [this\_state\_machine\_arn](#output\_this\_state\_machine\_arn) | The ARN of the State Machine |
+| <a name="output_this_state_machine_creation_date"></a> [this\_state\_machine\_creation\_date](#output\_this\_state\_machine\_creation\_date) | The date the State Machine was created |
+| <a name="output_this_state_machine_id"></a> [this\_state\_machine\_id](#output\_this\_state\_machine\_id) | The ARN of the State Machine |
+| <a name="output_this_state_machine_status"></a> [this\_state\_machine\_status](#output\_this\_state\_machine\_status) | The current status of the State Machine |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
