### PR TITLE
feat: Add support for EventBridge integration with PutEvents tasks

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -696,6 +696,7 @@ locals {
       }
     }
 
+    # https://docs.aws.amazon.com/step-functions/latest/dg/eventbridge-iam.html
     eventbridge = {
       eventbridge = {
         actions = [

--- a/locals.tf
+++ b/locals.tf
@@ -696,6 +696,15 @@ locals {
       }
     }
 
+    eventbridge = {
+      eventbridge = {
+        actions = [
+          "events:PutEvents"
+        ]
+        default_resources = ["*"]
+      }
+    }
+
     # https://docs.aws.amazon.com/step-functions/latest/dg/activities-iam.html
     no_tasks = {
       deny_all = {


### PR DESCRIPTION
## Description
Adding integration support for EventBridge PutEvents tasks

## Motivation and Context
AWS released support for PutEvents 
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html

## Breaking Changes
None

## How Has This Been Tested?
I tested the IAM policy would be generated via terraform after updating the example project.
