### PR TITLE
fix: Add default resource to ECS and Batch Events, IAM PassRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 <a name="unreleased"></a>
 ## [Unreleased]
-
+- feat: Add iam_PassRole integration ([#11](https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/11))
+- fix: Add default resource for ECS and Batch events ([#11](https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/11))
 
 
 <a name="v2.3.0"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 - feat: Add iam_PassRole integration ([#11](https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/11))
-- fix: Add default resource for ECS and Batch events ([#11](https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/11))
 
 
 <a name="v2.3.0"></a>

--- a/locals.tf
+++ b/locals.tf
@@ -291,6 +291,14 @@ locals {
       }
     }
 
+    # Allow service to pass role, ie for Fargate Task Execution role
+    # https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/11
+    iam = {
+      iam = {
+        actions = ["iam:PassRole"]
+      }
+    }
+
     # https://docs.aws.amazon.com/step-functions/latest/dg/sagemaker-iam.html
     sagemaker_CreateTrainingJob_Sync = {
       sagemaker = {

--- a/locals.tf
+++ b/locals.tf
@@ -293,8 +293,8 @@ locals {
 
     # Allow service to pass role, ie for Fargate Task Execution role
     # https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/11
-    iam_PassRole = {
-      iam = {
+    iam = {
+      iam_PassRole = {
         actions = ["iam:PassRole"]
       }
     }

--- a/locals.tf
+++ b/locals.tf
@@ -210,7 +210,6 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
-        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"]
       }
     }
 
@@ -257,7 +256,6 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
-        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForECSTaskRule"]
       }
     }
 
@@ -291,8 +289,6 @@ locals {
       }
     }
 
-    # Allow service to pass role, ie for Fargate Task Execution role
-    # https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/11
     iam = {
       iam_PassRole = {
         actions = ["iam:PassRole"]

--- a/locals.tf
+++ b/locals.tf
@@ -564,7 +564,7 @@ locals {
       }
     }
 
-    codebuild_BatcDeleteBuilds = {
+    codebuild_BatchDeleteBuilds = {
       codebuild = {
         actions = [
           "codebuild:BatchDeleteBuilds"

--- a/locals.tf
+++ b/locals.tf
@@ -210,6 +210,7 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
+        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"]
       }
     }
 
@@ -256,6 +257,7 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
+        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForECSTaskRule"]
       }
     }
 
@@ -554,7 +556,7 @@ locals {
       }
     }
 
-    codebuild_BatchDeleteBuilds = {
+    codebuild_BatcDeleteBuilds = {
       codebuild = {
         actions = [
           "codebuild:BatchDeleteBuilds"

--- a/locals.tf
+++ b/locals.tf
@@ -293,7 +293,7 @@ locals {
 
     # Allow service to pass role, ie for Fargate Task Execution role
     # https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/11
-    iam = {
+    iam_PassRole = {
       iam = {
         actions = ["iam:PassRole"]
       }

--- a/main.tf
+++ b/main.tf
@@ -37,9 +37,6 @@ resource "aws_sfn_state_machine" "this" {
 # IAM Role
 ###########
 
-data "aws_caller_identity" "current" {}
-
-
 data "aws_region" "current" {
   count = local.create_role && var.aws_region_assume_role == "" ? 1 : 0
 }

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,9 @@ resource "aws_sfn_state_machine" "this" {
 # IAM Role
 ###########
 
+data "aws_caller_identity" "current" {}
+
+
 data "aws_region" "current" {
   count = local.create_role && var.aws_region_assume_role == "" ? 1 : 0
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add default resource for ECS and Batch events. With out these resources usage of ECS and Batch service causes
`Error: AccessDeniedException: 'arn:aws:iam::xxxx:role/step-functions-role' is not authorized to create managed-rule.`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#11 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed module in own project with

```terraform
 batch_Sync = {
      batch = ["*"]
      events = true
    }

    iam_PassRole = {
      iam = ["*"]
    }
```

This allowed me to successfully deploy my step function with Batch Integration.
It also create a  Iam:PassRole policy and attached it to the service role.

```
# module.step_function.aws_iam_policy.service["iam_PassRole"] will be created
  + resource "aws_iam_policy" "service" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "project-step_function-test-batch-iam_PassRole"
      + path      = "/"
      + policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "iam:PassRole"
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "iamPassRoleIam"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id = (known after apply)
      + tags_all  = (known after apply)
    }

# module.step_function.aws_iam_policy_attachment.service["iam_PassRole"] will be created
  + resource "aws_iam_policy_attachment" "service" {
      + id         = (known after apply)
      + name       = "project-step_function-test-batch-iam_PassRole"
      + policy_arn = (known after apply)
      + roles      = [
          + "project-step_function-test-batch",
        ]
    }
```