### PR TITLE
feat: Adding IAM PassRole for ECS tasks as it is required for Fargate 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- feat: adding PassRole for ECS tasks as it is required for Fargate ([#24](https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/24))
 
 
 <a name="v2.4.0"></a>

--- a/locals.tf
+++ b/locals.tf
@@ -250,6 +250,19 @@ locals {
         default_resources = ["*"]
       }
 
+      iam_PassRole = {
+        actions = [
+          "iam:PassRole"
+        ]
+        condition = [
+          {
+            test     = "StringEquals"
+            variable = "iam:PassedToService"
+            values   = ["ecs-tasks.amazonaws.com"]
+          }
+        ]
+      }
+
       events = {
         actions = [
           "events:PutTargets",
@@ -263,6 +276,19 @@ locals {
       ecs = {
         actions = [
           "ecs:RunTask"
+        ]
+      }
+
+      iam_PassRole = {
+        actions = [
+          "iam:PassRole"
+        ]
+        condition = [
+          {
+            test     = "StringEquals"
+            variable = "iam:PassedToService"
+            values   = ["ecs-tasks.amazonaws.com"]
+          }
         ]
       }
     }


### PR DESCRIPTION
## Description
If one runs ECS tasks on Fargate, the task execution role mast be passed on. Otherwise one gets a `ECS.AccessDeniedException` error (more [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security_iam_troubleshoot.html#security_iam_troubleshoot-passrole) and [here](https://serverfault.com/questions/945596/why-does-aws-lambda-need-to-pass-ecstaskexecutionrole-to-ecs-task)). 

## Motivation and Context
This PR adds the possibility to reference the task execution role as any other resource in ECS tasks making it simpler for the user no to create erroneous `aws_iam_policy_document` documents.

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
Deployed in my own project filling out the 
```terraform
ecs_Sync = {
      ecs = [
        data.aws_ecs_task_definition.xxxx.id
      ]
      ecs_Wildcard = [
        data.aws_ecs_task_definition.xxxx.id
      ]
      iam_PassRole = [
        data.aws_iam_role.ecs_task_execution_role.arn
      ]
    }
```
which would add the statement
```terraform
                  + {
                      + Action    = "iam:PassRole"
                      + Condition = {
                          + StringEquals = {
                              + iam:PassedToService = [
                                  + "ecs-tasks.amazonaws.com",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "arn:aws:iam::xxxxxx:role/xxxxxxx"
                      + Sid       = "ecsSyncIamPassRole"
                    },
```
as well as without which results in adding statement to the policy (in that case it would not add or remove)
```terraform
                  - {
                      - Action    = "iam:PassRole"
                      - Condition = {
                          - StringEquals = {
                              - iam:PassedToService = [
                                  - "ecs-tasks.amazonaws.com",
                                ]
                            }
                        }
                      - Effect    = "Allow"
                      - Resource  = "arn:aws:iam::xxxxxx:role/xxxxxxx"
                      - Sid       = "ecsSyncIamPassRole"
                    },
```
The results for `ecs_WaitForTaskToken` is identical.