### PR TITLE
fix: The false result value has the wrong type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,10 @@ resource "aws_iam_role" "this" {
 ##############################
 
 data "aws_iam_policy_document" "service" {
-  for_each = local.create_role && var.attach_policies_for_integrations ? try(tomap(var.service_integrations), var.service_integrations) : tomap({})
+  for_each = {
+    for key, value in var.service_integrations : key => value
+    if local.create_role && var.attach_policies_for_integrations && value != null
+  }
 
   dynamic "statement" {
     for_each = each.value
@@ -106,14 +109,20 @@ data "aws_iam_policy_document" "service" {
 }
 
 resource "aws_iam_policy" "service" {
-  for_each = local.create_role && var.attach_policies_for_integrations ? try(tomap(var.service_integrations), var.service_integrations) : tomap({})
+  for_each = {
+    for key, value in var.service_integrations : key => value
+    if local.create_role && var.attach_policies_for_integrations && value != null
+  }
 
   name   = "${local.role_name}-${each.key}"
   policy = data.aws_iam_policy_document.service[each.key].json
 }
 
 resource "aws_iam_policy_attachment" "service" {
-  for_each = local.create_role && var.attach_policies_for_integrations ? try(tomap(var.service_integrations), var.service_integrations) : tomap({})
+  for_each = {
+    for key, value in var.service_integrations : key => value
+    if local.create_role && var.attach_policies_for_integrations && value != null
+  }
 
   name       = "${local.role_name}-${each.key}"
   roles      = [aws_iam_role.this[0].name]


### PR DESCRIPTION
## Description
Whenever you define your `service_integrations` and set `create_role` && `attach_policies_for_integrations` to false, you expect to have an empty map to skip the appropriate blocks and resources to be created within the module.
Therefore Terraform will throw an exception for not accepting different map structure within the same condition. The first one with your key/values you are providing and the second one is an empty map.

When executing `terraform plan` the below error appears:

```
│   on .terraform/modules/step_function/main.tf line 123, in resource "aws_iam_policy_attachment" "service":
│  85:   for_each = local.create_role && var.attach_policies_for_integrations ? try(tomap(var.service_integrations), var.service_integrations) : tomap({})
│ 
│ The false result value has the wrong type: map has no element for required attribute "lambda".
```


Used variables in order to reproduce it.
```

module "step_function" {
  . . . 

  create_role = false 
  attach_policies_for_integrations = false

  service_integrations = {

    lambda = {
      lambda = [. . . .]
    }

    xray = {
      xray = true
    }
}

. . . 

}

```

## Motivation and Context
This change keeps the same logic behind the conditions and resources creation, it's simply a different way of using values and condition with the for_each.
With this solution we create our map whenever we have values, and it skips the block when the condition is not met.

## Breaking Changes
There no really breaking changes

