### PR TITLE
docs: Make Readme Clearer where no default_resources specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ module "step_function" {
     }
 
     sqs = {
-      sqs = "arn:aws:sqs:..."  # sqs queue ARN is required because there is no default_resources key for such integration
+      sqs = ["arn:aws:sqs:..."]  # sqs queue ARN(s) is required because there is no default_resources key for such integration
     }
 
     # Special case to deny all actions for the step function (this will override all IAM policies allowed for the function)


### PR DESCRIPTION
## Description
Made a small fix to the README to clarify the setting of an ARN where there are no default_resources available

## Motivation and Context
It was a little confusing when following that the argument should have been a list not a string, the readme suggests this is a string

## Breaking Changes
None

## How Has This Been Tested?
Documentation change however implemented for batch_Sync/events this way
