### PR TITLE
Enabled tags for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+### Enabled Tagging For Iam-policy 
+
+<a name="v2.6.0"></a>
+## [v2.6.0] - 2022-04-10
+
+- feat: Enabled taging for iam policy resource ([#32](https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/32)
+
+
 ### [2.5.2](https://github.com/terraform-aws-modules/terraform-aws-step-functions/compare/v2.5.1...v2.5.2) (2022-01-14)
 
 
@@ -15,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 * update CI/CD process to enable auto-release workflow ([#26](https://github.com/terraform-aws-modules/terraform-aws-step-functions/issues/26)) ([660d759](https://github.com/terraform-aws-modules/terraform-aws-step-functions/commit/660d759b68d2ae9817fd1bc138885cddc58dfd2e))
+
 
 <a name="v2.5.0"></a>
 ## [v2.5.0] - 2021-09-15

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ resource "aws_iam_policy" "service" {
 
   name   = "${local.role_name}-${each.key}"
   policy = data.aws_iam_policy_document.service[each.key].json
+  tags = var.tags
 }
 
 resource "aws_iam_policy_attachment" "service" {
@@ -130,6 +131,7 @@ resource "aws_iam_policy" "additional_json" {
 
   name   = local.role_name
   policy = var.policy_json
+  tags = var.tags
 }
 
 resource "aws_iam_policy_attachment" "additional_json" {
@@ -149,6 +151,7 @@ resource "aws_iam_policy" "additional_jsons" {
 
   name   = "${local.role_name}-${count.index}"
   policy = var.policy_jsons[count.index]
+  tags = var.tags
 }
 
 resource "aws_iam_policy_attachment" "additional_jsons" {
@@ -232,6 +235,7 @@ resource "aws_iam_policy" "additional_inline" {
 
   name   = "${local.role_name}-inline"
   policy = data.aws_iam_policy_document.additional_inline[0].json
+  tags = var.tags
 }
 
 resource "aws_iam_policy_attachment" "additional_inline" {
@@ -273,6 +277,7 @@ resource "aws_iam_policy" "logs" {
 
   name   = "${local.role_name}-logs"
   policy = data.aws_iam_policy_document.logs[0].json
+  tags = var.tags
 }
 
 resource "aws_iam_policy_attachment" "logs" {


### PR DESCRIPTION
## Description
Enablement of tags for:
The ''aws_iam_policy" resource with 'service' resource name
The ''aws_iam_policy" resource with 'additional_json' resource name
The ''aws_iam_policy" resource with 'additional_jsons' resource name
The ''aws_iam_policy" resource with 'additional_inline' resource name
The ''aws_iam_policy" resource with 'logs' resource name

## Motivation and Context
When we began using the repo, we found that some of the resources are yet to be tag enabled. Hence when our internal projects were calling this repo, our custom tags were not being added in AWS. 

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)

