### PR TITLE
docs: sqs arn needs to be passed as a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module "step_function" {
     }
 
     sqs = {
-      sqs = "arn:aws:sqs:..."  # sqs queue ARN is required because there is no default_resources key for such integration
+      sqs = ["arn:aws:sqs:..."]  # sqs queue ARN is required because there is no default_resources key for such integration
     }
 
     # Special case to deny all actions for the step function (this will override all IAM policies allowed for the function)


### PR DESCRIPTION


## Description
The documentation example for the SQS service integration passes the value of the queue arn as is and not as a list.
If the arn is not passed as a list an invalid function argument is thrown:
Invalid value for "v" parameter: cannot convert string to list of any single type.

## Motivation and Context
The change is required to improve the readme documentation. If the example for the SQS service integration is followed as is it will generate the error mentioned above. 

## Breaking Changes
This is an update to the documentation. No breaking change would incur.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [*] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
