### PR TITLE
chore: SQS arn needs to be passed as a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module "step_function" {
     }
 
     sqs = {
-      sqs = "arn:aws:sqs:..."  # sqs queue ARN is required because there is no default_resources key for such integration
+      sqs = ["arn:aws:sqs:..."]  # sqs queue ARN is required because there is no default_resources key for such integration
     }
 
     # Special case to deny all actions for the step function (this will override all IAM policies allowed for the function)


### PR DESCRIPTION
If the arn is not passed as a list an invalid function argument is thrown:
Invalid value for "v" parameter: cannot convert string to list of any single type.

## Description
The documentation indication that for the step function service integration part to pass the sqs arn as a string instead of a list of string. If the arn is passed as a string it will generate the error above.

## Motivation and Context
The change to the doc will hopefully help with passing in the correct value required and avoid getting the exception mentioned above.

## Breaking Changes
This change is just for the documentation. So it should not introduce any breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [* ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
