### PR TITLE
fix: Move default resources for events for AWS Batch service integration

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -46,6 +46,10 @@ module "step_function" {
 
   service_integrations = {
 
+    batch_Sync = {
+      events = true
+    }
+
     dynamodb = {
       dynamodb = ["arn:aws:dynamodb:eu-west-1:052212379155:table/Test"]
     }

--- a/locals.tf
+++ b/locals.tf
@@ -210,8 +210,8 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
+        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"]
       }
-      default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"]
     }
 
     batch_WaitForTaskToken = {


### PR DESCRIPTION
## Description
`default_resources` for AWS Batch service integration (`events`) are not working correctly as in `locals.tf`
they belong to the outer scope `batch_Sync` whereas they should belong to the nested
`events` field.

My workaround for the problem was:
```
  service_integrations = {
    batch_Sync = {
      batch = true,
      events = [
      "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"],
    }
```
Which works, but it would be nice to fix and hide the events policy as for other services it works flawlessly. Thus the MR.

## Motivation / Context / Breaking Changes
No regression is being introduced as they field is not used currently (as it lies outside of the keys context either way):

![image](https://user-images.githubusercontent.com/23434261/199352175-6142fbf7-2a35-4f50-b06c-ec47242eb34f.png)


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

Tested with `init` and `plan`, on `master` plan does not work correctly:
![image](https://user-images.githubusercontent.com/23434261/199354473-e00b761f-c411-4e82-923f-0cfe2287bbc2.png)

After the changes everything is fine, 2 more resources as expected:
![image](https://user-images.githubusercontent.com/23434261/199354663-6afa7d2a-2fba-4e85-ba9a-606a3c6b81de.png)
![image](https://user-images.githubusercontent.com/23434261/199354710-d3a1e68d-0203-435c-b088-faec0aeeecd6.png)

