### PR TITLE
feat: Add output for the CloudWatch log group name and ARN created for the Step Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | The ARN of the CloudWatch log group created for the Step Function |
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | The name of the CloudWatch log group created for the Step Function |
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The ARN of the IAM role created for the Step Function |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the IAM role created for the Step Function |
 | <a name="output_state_machine_arn"></a> [state\_machine\_arn](#output\_state\_machine\_arn) | The ARN of the Step Function |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -61,6 +61,8 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | The ARN of the CloudWatch log group created for the Step Function |
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | The name of the CloudWatch log group created for the Step Function |
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The ARN of the IAM role created for the State Machine |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the IAM role created for the State Machine |
 | <a name="output_state_machine_arn"></a> [state\_machine\_arn](#output\_state\_machine\_arn) | The ARN of the State Machine |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -29,3 +29,14 @@ output "role_name" {
   description = "The name of the IAM role created for the State Machine"
   value       = module.step_function.role_name
 }
+
+# CloudWatch
+output "cloudwatch_log_group_arn" {
+  description = "The ARN of the CloudWatch log group created for the Step Function"
+  value       = module.step_function.cloudwatch_log_group_arn
+}
+
+output "cloudwatch_log_group_name" {
+  description = "The name of the CloudWatch log group created for the Step Function"
+  value       = module.step_function.cloudwatch_log_group_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,3 +29,14 @@ output "role_name" {
   description = "The name of the IAM role created for the Step Function"
   value       = try(aws_iam_role.this[0].name, "")
 }
+
+# CloudWatch
+output "cloudwatch_log_group_arn" {
+  description = "The ARN of the CloudWatch log group created for the Step Function"
+  value       = try(aws_cloudwatch_log_group.sfn[0].arn, "")
+}
+
+output "cloudwatch_log_group_name" {
+  description = "The name of the CloudWatch log group created for the Step Function"
+  value       = try(aws_cloudwatch_log_group.sfn[0].name, "")
+}


### PR DESCRIPTION
## Description
Add cloudwatch log group name and arn in output. This log group was already created by this module. This PR only adds the output.

## Motivation and Context
We need to connect the generated log group to log-metric-filter module using the name and the ARN of the log group created by this module.

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
