### PR TITLE
feat: Prefix the CloudWatch Log group name with  `/aws/vendedlogs/states/`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -301,7 +301,7 @@ data "aws_cloudwatch_log_group" "sfn" {
 resource "aws_cloudwatch_log_group" "sfn" {
   count = var.create && local.enable_logging && !var.use_existing_cloudwatch_log_group ? 1 : 0
 
-  name              = coalesce(var.cloudwatch_log_group_name, var.name)
+  name              = coalesce(var.cloudwatch_log_group_name, "/aws/vendedlogs/states/${var.name}")
   retention_in_days = var.cloudwatch_log_group_retention_in_days
   kms_key_id        = var.cloudwatch_log_group_kms_key_id
 


### PR DESCRIPTION
per https://docs.aws.amazon.com/step-functions/latest/dg/bp-cwl.html

Co-authored-by: @njorden

## Description
The AWS StepFunction docs suggest prefixing the log group for step functions with  "/aws/vendedlogs/states" to avoid message size limits. This is also the default for any group created via the console itself. This seems like a reasonable default for log groups created implicitly (i.e., when not named by the TF config). 

Vendors like [Datadog](https://docs.datadoghq.com/integrations/amazon_step_functions#log-collection) also expects logs to be prefixed as such in order to tag the logging as `source:stepfunction`. 

## Motivation and Context

AWS provides what appears to be a best practice guidance here that I think is worth following for implicit log group creation. It doesn't break anywhere that people already name their log groups. 

Resolves #36

## Breaking Changes
Does not break anything but will cause destructive changes to anyone using this module.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
