### PR TITLE
feat!: Upgraded Terraform version to 1.0+ and added configurable timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,14 +133,14 @@ module "step_function" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66 |
 
 ## Modules
 
@@ -209,6 +209,7 @@ No modules.
 | <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM role used by Step Function | `string` | `null` | no |
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
 | <a name="input_service_integrations"></a> [service\_integrations](#input\_service\_integrations) | Map of AWS service integrations to allow in IAM role policy | `any` | `{}` | no |
+| <a name="input_sfn_state_machine_timeouts"></a> [sfn\_state\_machine\_timeouts](#input\_sfn\_state\_machine\_timeouts) | Create, update, and delete timeout configurations for the step function. | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Maps of tags to assign to the Step Function | `map(string)` | `{}` | no |
 | <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | Step Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
 | <a name="input_type"></a> [type](#input\_type) | Determines whether a Standard or Express state machine is created. The default is STANDARD. Valid Values: STANDARD \| EXPRESS | `string` | `"STANDARD"` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,8 +22,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
@@ -31,7 +31,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -151,6 +151,12 @@ EOF
   # END: Additional policies
   ###########################
 
+  sfn_state_machine_timeouts = {
+    create = "30m"
+    delete = "50m"
+    update = "30m"
+  }
+
   tags = {
     Module = "step_function"
   }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
-    aws    = ">= 3.27"
+    aws    = ">= 4.66"
     random = ">= 2"
     null   = ">= 2"
   }

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,12 @@ resource "aws_sfn_state_machine" "this" {
 
   type = upper(var.type)
 
+  timeouts {
+    create = lookup(var.sfn_state_machine_timeouts, "create", null)
+    delete = lookup(var.sfn_state_machine_timeouts, "delete", null)
+    update = lookup(var.sfn_state_machine_timeouts, "update", null)
+  }
+
   tags = merge({ Name = var.name }, var.tags)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,12 @@ variable "type" {
   }
 }
 
+variable "sfn_state_machine_timeouts" {
+  description = "Create, update, and delete timeout configurations for the step function."
+  type        = map(string)
+  default     = {}
+}
+
 #################
 # CloudWatch Logs
 #################

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
-    aws = ">= 3.27"
+    aws = ">= 4.66"
   }
 }


### PR DESCRIPTION
## Description
Add configurable timeouts to step function resource. 
Also upgrade AWS provider version to >= 4.66 and terraform version to >= 1.0.

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/31097

## Breaking Changes
Terraform >= 1.0 support. 
AWS provider version >=4.66 from v3. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
