### PR TITLE
fix: Fixed stepfunction_Sync action

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -702,7 +702,7 @@ locals {
     stepfunction_Sync = {
       stepfunction = {
         actions = [
-          "states:StartExecution"
+          "states:StartSyncExecution"
         ]
       }
 


### PR DESCRIPTION
Thanks, Johannes Koch (@Lock128) for figuring out this!

Official docs are not correct on this.

`StartExecution` is for STANDARD StepFunctions, and `StartSyncExecution` is for EXPRESS StepFunctions.