### PR TITLE
feat: Add optional policy_path variable used for policy definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ No modules.
 | <a name="input_policy"></a> [policy](#input\_policy) | An additional policy document ARN to attach to IAM role | `string` | `null` | no |
 | <a name="input_policy_json"></a> [policy\_json](#input\_policy\_json) | An additional policy document as JSON to attach to IAM role | `string` | `null` | no |
 | <a name="input_policy_jsons"></a> [policy\_jsons](#input\_policy\_jsons) | List of additional policy documents as JSON to attach to IAM role | `list(string)` | `[]` | no |
-| <a name="input_policy_path"></a> [policy\_path](#input\_policy\_path) | Path of IAM policies to use for Step Function | `string` | `"/"` | no |
+| <a name="input_policy_path"></a> [policy\_path](#input\_policy\_path) | Path of IAM policies to use for Step Function | `string` | `null` | no |
 | <a name="input_policy_statements"></a> [policy\_statements](#input\_policy\_statements) | Map of dynamic policy statements to attach to IAM role | `any` | `{}` | no |
 | <a name="input_publish"></a> [publish](#input\_publish) | Determines whether to set a version of the state machine when it is created. | `bool` | `false` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | The Amazon Resource Name (ARN) of the IAM role to use for this Step Function | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ No modules.
 | <a name="input_policy"></a> [policy](#input\_policy) | An additional policy document ARN to attach to IAM role | `string` | `null` | no |
 | <a name="input_policy_json"></a> [policy\_json](#input\_policy\_json) | An additional policy document as JSON to attach to IAM role | `string` | `null` | no |
 | <a name="input_policy_jsons"></a> [policy\_jsons](#input\_policy\_jsons) | List of additional policy documents as JSON to attach to IAM role | `list(string)` | `[]` | no |
+| <a name="input_policy_path"></a> [policy\_path](#input\_policy\_path) | Path of IAM policies to use for Step Function | `string` | `"/"` | no |
 | <a name="input_policy_statements"></a> [policy\_statements](#input\_policy\_statements) | Map of dynamic policy statements to attach to IAM role | `any` | `{}` | no |
 | <a name="input_publish"></a> [publish](#input\_publish) | Determines whether to set a version of the state machine when it is created. | `bool` | `false` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | The Amazon Resource Name (ARN) of the IAM role to use for this Step Function | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,7 @@ resource "aws_iam_policy" "service" {
   for_each = { for k, v in var.service_integrations : k => v if local.create_role && var.attach_policies_for_integrations }
 
   name   = "${local.role_name}-${each.key}"
+  path   = var.policy_path
   policy = data.aws_iam_policy_document.service[each.key].json
   tags   = var.tags
 }
@@ -137,6 +138,7 @@ resource "aws_iam_policy" "additional_json" {
   count = local.create_role && var.attach_policy_json ? 1 : 0
 
   name   = local.role_name
+  path   = var.policy_path
   policy = var.policy_json
   tags   = var.tags
 }
@@ -157,6 +159,7 @@ resource "aws_iam_policy" "additional_jsons" {
   count = local.create_role && var.attach_policy_jsons ? var.number_of_policy_jsons : 0
 
   name   = "${local.role_name}-${count.index}"
+  path   = var.policy_path
   policy = var.policy_jsons[count.index]
   tags   = var.tags
 }
@@ -241,6 +244,7 @@ resource "aws_iam_policy" "additional_inline" {
   count = local.create_role && var.attach_policy_statements ? 1 : 0
 
   name   = "${local.role_name}-inline"
+  path   = var.policy_path
   policy = data.aws_iam_policy_document.additional_inline[0].json
   tags   = var.tags
 }
@@ -283,6 +287,7 @@ resource "aws_iam_policy" "logs" {
   count = local.create_role && local.enable_logging && var.attach_cloudwatch_logs_policy ? 1 : 0
 
   name   = "${local.role_name}-logs"
+  path   = var.policy_path
   policy = data.aws_iam_policy_document.logs[0].json
   tags   = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -246,6 +246,12 @@ variable "policy" {
   default     = null
 }
 
+variable "policy_path" {
+  description = "Path of IAM policies to use for Step Function"
+  type        = string
+  default     = "/"
+}
+
 variable "policies" {
   description = "List of policy statements ARN to attach to IAM role"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -249,7 +249,7 @@ variable "policy" {
 variable "policy_path" {
   description = "Path of IAM policies to use for Step Function"
   type        = string
-  default     = "/"
+  default     = null
 }
 
 variable "policies" {


### PR DESCRIPTION
## Description
Add optional policy_path variable used for policy definitions.

## Motivation and Context
If you are using policy_path for security reasons and need to set the policy_path, you will not be able to use the [terraform-aws-step-functions](https://github.com/terraform-aws-modules/terraform-aws-step-functions). With this change, the path can be configured using the policy_path variable, or leave the default "/" if the variable is omitted.

## Breaking Changes
No Breaking Changes the default for policy_path remains "/".

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
I have not updated the examples as `role_path` is also not used in the examples and I suspect that it was done that way on purpose. 
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
