### PR TITLE
feat: Add new output with state machine name

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ No modules.
 | <a name="output_state_machine_arn"></a> [state\_machine\_arn](#output\_state\_machine\_arn) | The ARN of the Step Function |
 | <a name="output_state_machine_creation_date"></a> [state\_machine\_creation\_date](#output\_state\_machine\_creation\_date) | The date the Step Function was created |
 | <a name="output_state_machine_id"></a> [state\_machine\_id](#output\_state\_machine\_id) | The ARN of the Step Function |
+| <a name="output_state_machine_name"></a> [state\_machine\_name](#output\_state\_machine\_name) | The Name of the Step Function |
 | <a name="output_state_machine_status"></a> [state\_machine\_status](#output\_state\_machine\_status) | The current status of the Step Function |
 | <a name="output_state_machine_version_arn"></a> [state\_machine\_version\_arn](#output\_state\_machine\_version\_arn) | The ARN of state machine version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,11 @@ output "state_machine_arn" {
   value       = try(aws_sfn_state_machine.this[0].arn, "")
 }
 
+output "state_machine_name" {
+  description = "The Name of the Step Function"
+  value       = try(var.name, "")
+}
+
 output "state_machine_creation_date" {
   description = "The date the Step Function was created"
   value       = try(aws_sfn_state_machine.this[0].creation_date, "")

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "state_machine_arn" {
 
 output "state_machine_name" {
   description = "The Name of the Step Function"
-  value       = try(var.name, "")
+  value       = try(aws_sfn_state_machine.this[0].name, "")
 }
 
 output "state_machine_creation_date" {


### PR DESCRIPTION
### **Description**

Add new output with StepFunction name

### **Motivation and Context**

I have got an use case where I need to reference the name of step function. 
Instead of hardcoding it I would like to obtain it from the module directly.

### **Breaking Changes**

No Breaking Changes. Only adds new output based on existing variable name

### **How Has This Been Tested?**

- [x]  I have executed pre-commit run -a on my pull request